### PR TITLE
Add carbon.apimgt.pkg.version

### DIFF
--- a/components/azure.key.manager/pom.xml
+++ b/components/azure.key.manager/pom.xml
@@ -81,7 +81,11 @@
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Export-Package> org.wso2.azure.client.*;version="${project.version}"
                         </Export-Package>
-                        <Import-Package> com.google.gson.*;version="[2.1,3)", org.wso2.carbon.apimgt.api.*;version="${carbon.apimgt.version}", org.wso2.carbon.apimgt.impl.*;version="${carbon.apimgt.version}", *;resolution:=optional
+                        <Import-Package>
+                            com.google.gson.*;version="[2.1,3)",
+                            org.wso2.carbon.apimgt.api.*;version="${carbon.apimgt.imp.pkg.version}",
+                            org.wso2.carbon.apimgt.impl.*;version="${carbon.apimgt.imp.pkg.version}",
+                            *;resolution:=optional
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,8 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <carbon.apimgt.version>9.20.34</carbon.apimgt.version>
+    <carbon.apimgt.version>6.7.206</carbon.apimgt.version>
+    <carbon.apimgt.imp.pkg.version>[6.7.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
     <json.simple.version>1.1</json.simple.version>
     <gson.version>2.9.1</gson.version>
     <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>


### PR DESCRIPTION
This PR adds carbon.apimgt.pkg.version to pom files to work with apim 3.2.0, apim 4.0.0 & apim 4.1.0 products.