### PR TITLE
Set client_name parameter to OAuthApplicationInfo

### DIFF
--- a/components/azure.key.manager/src/main/java/org/wso2/azure/client/AzureADClient.java
+++ b/components/azure.key.manager/src/main/java/org/wso2/azure/client/AzureADClient.java
@@ -151,6 +151,10 @@ public class AzureADClient extends AbstractKeyManager {
             oauthAppInfo.setClientSecret(appInfo.getClientSecret());
         }
 
+        if (StringUtils.isNotEmpty(appInfo.getAppName())) {
+            oauthAppInfo.addParameter(ApplicationConstants.OAUTH_CLIENT_NAME, appInfo.getAppName());
+        }
+
         oauthAppInfo.addParameter(ApplicationConstants.OAUTH_CLIENT_GRANT,
                 AzureADConstants.CLIENT_CREDENTIALS_GRANT_TYPE);
 


### PR DESCRIPTION
## Purpose
This PR adds the "client_name" parameter to OAuthApplicationInfo for Azure AD clients.

Fixes https://github.com/wso2/api-manager/issues/1900