### PR TITLE
Support default scope in regional cloud environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ target/
 .mvn/
 mvnw
 .idea
+.DS_Store

--- a/components/azure.key.manager/src/main/java/org/wso2/azure/client/AzureADClient.java
+++ b/components/azure.key.manager/src/main/java/org/wso2/azure/client/AzureADClient.java
@@ -63,13 +63,14 @@ public class AzureADClient extends AbstractKeyManager {
         String appClientSecret = (String) this.configuration.getParameter(AzureADConstants.AD_APP_CLIENT_SECRET);
         String revokeEndpoint = (String) this.configuration.getParameter(APIConstants.KeyManager.REVOKE_ENDPOINT);
         String graphApiEndpoint = (String) this.configuration.getParameter(AzureADConstants.GRAPH_API_ENDPOINT);
+        String graphApiDefaultScope = graphApiEndpoint + AzureADConstants.GRAPH_API_DEFAULT_SCOPE_SUFFIX;
 
         tokenEndpoint = (String) this.configuration.getParameter(APIConstants.KeyManager.TOKEN_ENDPOINT);
 
         AccessTokenGenerator accessTokenGenerator = new AccessTokenGenerator(tokenEndpoint, revokeEndpoint, appClientId,
                 appClientSecret);
 
-        AzureADRequestInterceptor appInterceptor = new AzureADRequestInterceptor(accessTokenGenerator);
+        AzureADRequestInterceptor appInterceptor = new AzureADRequestInterceptor(accessTokenGenerator, graphApiDefaultScope);
 
         appClient = this.buildFeignClient(new OkHttpClient(), appInterceptor)
                 .target(ApplicationClient.class, graphApiEndpoint);

--- a/components/azure.key.manager/src/main/java/org/wso2/azure/client/AzureADConstants.java
+++ b/components/azure.key.manager/src/main/java/org/wso2/azure/client/AzureADConstants.java
@@ -32,9 +32,9 @@ public class AzureADConstants {
     public static final String AD_APP_CLIENT_ID = "azure_ad_client_id";
     public static final String AD_APP_CLIENT_SECRET = "azure_ad_client_secret";
     public static final String AD_APP_TENANT = "azure_ad_tenant";
-    public static final String MICROSOFT_DEFAULT_SCOPE = "https://graph.microsoft.com/.default";
     public static final String API_ID_URI_TEMPLATE = "api://%s";
     public static final String API_SCOPE_TEMPLATE = "api://%s/.default";
+    public static final String GRAPH_API_DEFAULT_SCOPE_SUFFIX = "/.default";
 
     public static final String GRANT_TYPE = "grant_type";
     public static final String SCOPE = "scope";

--- a/components/azure.key.manager/src/main/java/org/wso2/azure/client/AzureADRequestInterceptor.java
+++ b/components/azure.key.manager/src/main/java/org/wso2/azure/client/AzureADRequestInterceptor.java
@@ -26,14 +26,16 @@ import feign.RequestTemplate;
 public class AzureADRequestInterceptor implements RequestInterceptor {
 
     private AccessTokenGenerator accessTokenGenerator;
+    private String defaultScope;
 
-    public AzureADRequestInterceptor(AccessTokenGenerator accessTokenGenerator) {
+    public AzureADRequestInterceptor(AccessTokenGenerator accessTokenGenerator, String defaultScope) {
         this.accessTokenGenerator = accessTokenGenerator;
+        this.defaultScope = defaultScope;
     }
 
     @Override
     public void apply(RequestTemplate requestTemplate) {
-        String[] scopes = { AzureADConstants.MICROSOFT_DEFAULT_SCOPE };
+        String[] scopes = { defaultScope };
         String accessToken = accessTokenGenerator.getAccessToken(scopes);
         requestTemplate
                 .header(APIConstants.AUTHORIZATION_HEADER_DEFAULT, APIConstants.AUTHORIZATION_BEARER + accessToken);


### PR DESCRIPTION
## Purpose
This PR supports the default scope in Azure AD in region specific cloud environments. The value `https://graph.microsoft.com/.default` is not valid if the Azure Graph API is in a separate National Cloud deployment.

Related internal: https://github.com/wso2-enterprise/wso2-apim-internal/issues/5485

Related issue: https://github.com/wso2/api-manager/issues/2456