### PR TITLE
Azuread v2

### DIFF
--- a/components/azure.key.manager/src/main/java/org/wso2/azure/client/ApplicationClient.java
+++ b/components/azure.key.manager/src/main/java/org/wso2/azure/client/ApplicationClient.java
@@ -20,6 +20,7 @@ package org.wso2.azure.client;
 import org.wso2.azure.client.model.ClientInformation;
 import org.wso2.azure.client.model.ClientInformationList;
 import org.wso2.azure.client.model.PasswordInfo;
+import org.wso2.azure.client.model.ServicePrincipalRequest;
 import org.wso2.carbon.apimgt.impl.kmclient.KeyManagerClientException;
 
 import feign.Headers;
@@ -75,6 +76,11 @@ public interface ApplicationClient {
 	@RequestLine("PATCH /v1.0/applications/{id}")
 	@Headers("Content-Type: application/json")
 	public void updateApplication(@Param("id") String id, ClientInformation applicationInfo)
+			throws KeyManagerClientException;
+
+	@RequestLine("POST /v1.0/servicePrincipals")
+	@Headers("Content-Type: application/json")
+	public void createServicePrincipal(ServicePrincipalRequest servicePrincipalRequest)
 			throws KeyManagerClientException;
 
 	@RequestLine("POST /v1.0/applications/{id}/addPassword")

--- a/components/azure.key.manager/src/main/java/org/wso2/azure/client/AzureADClient.java
+++ b/components/azure.key.manager/src/main/java/org/wso2/azure/client/AzureADClient.java
@@ -46,10 +46,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
-import static org.wso2.azure.client.AzureADConstants.AZURE_AD_ALLOWED_ACCESS_TOKEN_VERSIONS;
-import static org.wso2.azure.client.AzureADConstants.AZURE_AD_DEFAULT_REQUESTED_ACCESS_TOKEN_VERSION;
-import static org.wso2.azure.client.AzureADConstants.AZURE_AD_REQUESTED_ACCESS_TOKEN_VERSION;
-
 public class AzureADClient extends AbstractKeyManager {
 
     private static final Log log = LogFactory.getLog(AzureADClient.class);
@@ -70,7 +66,8 @@ public class AzureADClient extends AbstractKeyManager {
         String appClientSecret = (String) this.configuration.getParameter(AzureADConstants.AD_APP_CLIENT_SECRET);
         String revokeEndpoint = (String) this.configuration.getParameter(APIConstants.KeyManager.REVOKE_ENDPOINT);
         String graphApiEndpoint = (String) this.configuration.getParameter(AzureADConstants.GRAPH_API_ENDPOINT);
-        requestedAccessTokenVersion = (String) configuration.getParameter(AZURE_AD_REQUESTED_ACCESS_TOKEN_VERSION);
+        requestedAccessTokenVersion =
+                (String) this.configuration.getParameter(AzureADConstants.AZURE_AD_REQUESTED_ACCESS_TOKEN_VERSION);
         String graphApiDefaultScope = graphApiEndpoint + AzureADConstants.GRAPH_API_DEFAULT_SCOPE_SUFFIX;
 
         tokenEndpoint = (String) this.configuration.getParameter(APIConstants.KeyManager.TOKEN_ENDPOINT);
@@ -211,9 +208,9 @@ public class AzureADClient extends AbstractKeyManager {
     private int validateAndGetRequestedAccessTokenVersion(String requestedAccessTokenVersion)
             throws APIManagementException {
         if (requestedAccessTokenVersion == null) {
-            return AZURE_AD_DEFAULT_REQUESTED_ACCESS_TOKEN_VERSION;
+            return AzureADConstants.AZURE_AD_DEFAULT_REQUESTED_ACCESS_TOKEN_VERSION;
         }
-        Integer version = AZURE_AD_ALLOWED_ACCESS_TOKEN_VERSIONS.get(requestedAccessTokenVersion);
+        Integer version = AzureADConstants.AZURE_AD_ALLOWED_ACCESS_TOKEN_VERSIONS.get(requestedAccessTokenVersion);
         if (version != null) {
             return version;
         }

--- a/components/azure.key.manager/src/main/java/org/wso2/azure/client/AzureADClient.java
+++ b/components/azure.key.manager/src/main/java/org/wso2/azure/client/AzureADClient.java
@@ -30,6 +30,7 @@ import org.wso2.azure.client.model.ClientInformation;
 import org.wso2.azure.client.model.ClientInformationList;
 import org.wso2.azure.client.model.PasswordCredential;
 import org.wso2.azure.client.model.PasswordInfo;
+import org.wso2.azure.client.model.ServicePrincipalRequest;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.*;
 import org.wso2.carbon.apimgt.impl.APIConstants;
@@ -107,6 +108,9 @@ public class AzureADClient extends AbstractKeyManager {
                     // update Application ID URI, Otherwise the token will be in v1.
                     this.updateApplicationIDURI(app.getId(), app.getClientId());
 
+                    // Create servicePrincipal
+                    this.createServicePrincipalForApplication(app.getClientId());
+
                     return getOAuthApplicationInfo(app);
                 } else {
                     throw new APIManagementException("Client Application creation failed");
@@ -142,6 +146,12 @@ public class AzureADClient extends AbstractKeyManager {
         String applicationIdUri = String.format(AzureADConstants.API_ID_URI_TEMPLATE, appId);
         info.setIdentifierUris(new String[] { applicationIdUri });
         appClient.updateApplication(id, info);
+    }
+
+    private void createServicePrincipalForApplication(String appId) throws KeyManagerClientException {
+        ServicePrincipalRequest servicePrincipalRequest = new ServicePrincipalRequest();
+        servicePrincipalRequest.setAppId(appId);
+        appClient.createServicePrincipal(servicePrincipalRequest);
     }
 
     private OAuthApplicationInfo getOAuthApplicationInfo(ClientInformation appInfo) {

--- a/components/azure.key.manager/src/main/java/org/wso2/azure/client/AzureADConnectorConfiguration.java
+++ b/components/azure.key.manager/src/main/java/org/wso2/azure/client/AzureADConnectorConfiguration.java
@@ -20,12 +20,15 @@ package org.wso2.azure.client;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.osgi.service.component.annotations.Component;
 import org.wso2.carbon.apimgt.api.model.ConfigurationDto;
 import org.wso2.carbon.apimgt.api.model.KeyManagerConnectorConfiguration;
 
 import edu.emory.mathcs.backport.java.util.Arrays;
+
+import static org.wso2.azure.client.AzureADConstants.AZURE_AD_ALLOWED_ACCESS_TOKEN_VERSIONS;
 
 @Component(name = "azuread.configuration.component", immediate = true, service = KeyManagerConnectorConfiguration.class)
 public class AzureADConnectorConfiguration implements KeyManagerConnectorConfiguration {
@@ -54,6 +57,21 @@ public class AzureADConnectorConfiguration implements KeyManagerConnectorConfigu
                         "Microsoft Graph API Endpoint Version", "select",
                         "Microsoft's Graph API Endpoint Version", "v1.0", true,
                         false, Arrays.asList(versions), false));
+        configurationDtoList
+                .add(new ConfigurationDto(
+                        AzureADConstants.AZURE_AD_REQUESTED_ACCESS_TOKEN_VERSION,
+                        "Requested Access Token Version",
+                        "options",
+                        "Select the requested access token version",
+                        "v1.0",
+                        false,
+                        false,
+                        AZURE_AD_ALLOWED_ACCESS_TOKEN_VERSIONS.keySet().stream()
+                                .sorted()
+                                .collect(Collectors.toList()),
+                        false,
+                        true
+                ));
         configurationDtoList
                 .add(new ConfigurationDto(AzureADConstants.AD_APP_CLIENT_ID, "Client ID", "input",
                         "Azure AD App Client ID", "", true,

--- a/components/azure.key.manager/src/main/java/org/wso2/azure/client/AzureADConnectorConfiguration.java
+++ b/components/azure.key.manager/src/main/java/org/wso2/azure/client/AzureADConnectorConfiguration.java
@@ -28,8 +28,6 @@ import org.wso2.carbon.apimgt.api.model.KeyManagerConnectorConfiguration;
 
 import edu.emory.mathcs.backport.java.util.Arrays;
 
-import static org.wso2.azure.client.AzureADConstants.AZURE_AD_ALLOWED_ACCESS_TOKEN_VERSIONS;
-
 @Component(name = "azuread.configuration.component", immediate = true, service = KeyManagerConnectorConfiguration.class)
 public class AzureADConnectorConfiguration implements KeyManagerConnectorConfiguration {
 
@@ -66,7 +64,7 @@ public class AzureADConnectorConfiguration implements KeyManagerConnectorConfigu
                         "v1.0",
                         false,
                         false,
-                        AZURE_AD_ALLOWED_ACCESS_TOKEN_VERSIONS.keySet().stream()
+                        AzureADConstants.AZURE_AD_ALLOWED_ACCESS_TOKEN_VERSIONS.keySet().stream()
                                 .sorted()
                                 .collect(Collectors.toList()),
                         false,

--- a/components/azure.key.manager/src/main/java/org/wso2/azure/client/AzureADConstants.java
+++ b/components/azure.key.manager/src/main/java/org/wso2/azure/client/AzureADConstants.java
@@ -17,6 +17,10 @@
  */
 package org.wso2.azure.client;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 public class AzureADConstants {
 
     public static final String AZURE = "Azure AD";
@@ -25,6 +29,7 @@ public class AzureADConstants {
 
     public static final String GRAPH_API_ENDPOINT = "microsoft_graph_api_endpoint";
     public static final String GRAPH_API_ENDPOINT_VALUE = "https://graph.microsoft.com";
+    public static final String AZURE_AD_REQUESTED_ACCESS_TOKEN_VERSION = "azure_ad_requested_access_token_version";
     public static final String GRAPH_API_ENDPOINT_VERSION = "v1.0";
     // public static final String APP_ID = "appid";
     public static final String AZP = "azp";
@@ -42,4 +47,12 @@ public class AzureADConstants {
     public static final String BASIC = "Basic ";
     public static final String CONTENT_TYPE_URL_ENCODED = "application/x-www-form-urlencoded";
 
+    public static final int AZURE_AD_DEFAULT_REQUESTED_ACCESS_TOKEN_VERSION = 1;
+    public static final Map<String, Integer> AZURE_AD_ALLOWED_ACCESS_TOKEN_VERSIONS;
+    static {
+        Map<String, Integer> map = new HashMap<>();
+        map.put("v1.0", 1);
+        map.put("v2.0", 2);
+        AZURE_AD_ALLOWED_ACCESS_TOKEN_VERSIONS = Collections.unmodifiableMap(map);
+    }
 }

--- a/components/azure.key.manager/src/main/java/org/wso2/azure/client/model/ApiConfiguration.java
+++ b/components/azure.key.manager/src/main/java/org/wso2/azure/client/model/ApiConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2025 WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *http://www.apache.org/licenses/LICENSE-2.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.azure.client.model;
+
+import com.google.gson.annotations.SerializedName;
+
+public class ApiConfiguration {
+    @SerializedName("requestedAccessTokenVersion")
+    private int requestedAccessTokenVersion;
+
+    public int getRequestedAccessTokenVersion() {
+        return requestedAccessTokenVersion;
+    }
+
+    public void setRequestedAccessTokenVersion(int requestedAccessTokenVersion) {
+        this.requestedAccessTokenVersion = requestedAccessTokenVersion;
+    }
+
+    @Override
+    public String toString() {
+        return "ApiConfiguration [requestedAccessTokenVersion=" + requestedAccessTokenVersion + "]";
+    }
+}

--- a/components/azure.key.manager/src/main/java/org/wso2/azure/client/model/ClientInformation.java
+++ b/components/azure.key.manager/src/main/java/org/wso2/azure/client/model/ClientInformation.java
@@ -33,6 +33,9 @@ public class ClientInformation {
     @SerializedName("identifierUris")
     private String[] identifierUris;
 
+    @SerializedName("api")
+    private ApiConfiguration api;
+
     private String clientSecret;
 
     public String getId() {
@@ -75,9 +78,18 @@ public class ClientInformation {
         this.identifierUris = identifierUris;
     }
 
+    public ApiConfiguration getApi() {
+        return api;
+    }
+
+    public void setApi(ApiConfiguration api) {
+        this.api = api;
+    }
+
     @Override
     public String toString() {
-        return "ClientInformation [id=" + id + ", clientId=" + clientId + ", appName=" + appName + "]";
+        return "ClientInformation [id=" + id + ", clientId=" + clientId + ", appName=" + appName +
+                ", api=" + api + "]";
     }
 
 }

--- a/components/azure.key.manager/src/main/java/org/wso2/azure/client/model/ServicePrincipalRequest.java
+++ b/components/azure.key.manager/src/main/java/org/wso2/azure/client/model/ServicePrincipalRequest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2025 WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.azure.client.model;
+
+import com.google.gson.annotations.SerializedName;
+
+public class ServicePrincipalRequest {
+    @SerializedName("appId")
+    private String appId;
+
+    public String getAppId() {
+        return appId;
+    }
+
+    public void setAppId(String appId) {
+        this.appId = appId;
+    }
+
+    @Override
+    public String toString() {
+        return "ClientInformation [appId=" + appId +"]";
+    }
+}
+

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <carbon.apimgt.version>9.30.67.53</carbon.apimgt.version>
+    <carbon.apimgt.version>9.32.48</carbon.apimgt.version>
     <carbon.apimgt.imp.pkg.version>[6.7.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
     <json.simple.version>1.1.1</json.simple.version>
     <gson.version>2.10.1</gson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <carbon.apimgt.version>6.7.206</carbon.apimgt.version>
+    <carbon.apimgt.version>9.30.67.53</carbon.apimgt.version>
     <carbon.apimgt.imp.pkg.version>[6.7.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
     <json.simple.version>1.1.1</json.simple.version>
     <gson.version>2.10.1</gson.version>


### PR DESCRIPTION
## Purpose
This PR introduces support for Azure AD V2 token generation and addresses an issue where newly created Azure AD applications fail to generate tokens because the `service principal` permission is not automatically assigned by Azure.

## Issues
https://github.com/wso2/api-manager/issues/4185